### PR TITLE
Added ability to sign-in/sign-out

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react'
-
 import {
   Route, 
   Routes,
@@ -15,41 +13,38 @@ import {
   SignInPage
 } from "./components/pages"
 
+import HeaderLayout from "./components/HeaderLayout"
 import BlobsLayout from "./components/BlobsLayout"
 import AppLayout from "./components/AppLayout"
 import PrivateRoute from './components/PrivateRoute'
-import isUserLoggedIn from "./helpers/isUserLoggedIn"
-
+import AppContext from "./components/AppContext"
 
 import "./App.css"
 import "./reset.css"
 
 function App() {
-  const [ isLoggedIn, setIsLoggedIn ] = useState<boolean>(isUserLoggedIn());
-  const [ userID, setUserID ] = useState<string | undefined>(undefined);
-
-  const handleLogin = (userID: string) => {
-    localStorage.setItem("user_id", userID);
-    setUserID(userID)
-    setIsLoggedIn(true);
-  }
-
   return (
-    <Routes>
-      <Route element={<AppLayout />}>
-        <Route element={<BlobsLayout />}>
-          <Route index path="/" element={<HomePage userID={userID}/>}/>
-          <Route path="/about" element={<AboutPage />}/>
-          <Route path="/mission" element={<MissionPage />}/>
-          <Route path="/contact" element={<ContactPage />}/>
-          <Route path="/signin" element={<SignInPage handleLogin={handleLogin}/>}/>
+    <AppContext>
+      <Routes>
+        <Route element={<AppLayout />}>
+          <Route element={<HeaderLayout/>}>
+            <Route element={<BlobsLayout />}>
+              <Route index path="/" element={<HomePage />}/>
+              <Route path="/about" element={<AboutPage />}/>
+              <Route path="/mission" element={<MissionPage />}/>
+              <Route path="/contact" element={<ContactPage />}/>
+            </Route>
+            <Route element={<PrivateRoute />}>
+              <Route path={`/:user_id/videos`} element={<VideosPage />}/>
+              <Route path={`/:user_id/videos/:video_id`} element={<VideoPage />}/>
+            </Route>
+            <Route element={<BlobsLayout />}>
+              <Route path="/signin" element={<SignInPage />} />
+            </Route>
+          </Route>
         </Route>
-        <Route element={<PrivateRoute isAuthenticated={isLoggedIn}/>}>
-          <Route path={`/${userID}/videos`} element={<VideosPage />}/>
-          <Route path={`/${userID}/videos/:video_id`} element={<VideoPage />}/>
-        </Route>
-      </Route>
-    </Routes>
+      </Routes>
+    </AppContext>
   )
 }
 

--- a/src/components/AppContext/index.tsx
+++ b/src/components/AppContext/index.tsx
@@ -1,0 +1,46 @@
+import { useState, useEffect, useReducer } from "react"
+import { useNavigate, useLocation } from "react-router-dom"
+import isUserLoggedIn from "../../helpers/isUserLoggedIn"
+import getUserID from "../../helpers/getUserID"
+import userReducer from "../../helpers/userReducer"
+import appContext from "../../helpers/appContext"
+
+function AppContext({ children }: { children: React.ReactNode }) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [ user, setUser ] = useReducer(
+    userReducer, 
+    { 
+      isLoggedIn: isUserLoggedIn(),
+      userID: getUserID()
+    }
+  )
+
+  const handleLogin = (userID: string) => {
+    const destination = location?.state?.from?.replace(":user_id", userID) || "/";
+    localStorage.setItem("user_id", userID);
+    setUser({ type: "login", userID })
+    navigate(destination)
+  }
+
+  const handleLogout = () => {
+    localStorage.removeItem("user_id");
+    setUser({ type: "logout" })
+    navigate("/")
+  }
+
+  const appContextValue: AppContext = {
+    user,
+    setUser,
+    handleLogin,
+    handleLogout
+  }
+
+  return (
+    <appContext.Provider value={appContextValue}>
+      { children }
+    </appContext.Provider>
+  )
+}
+
+export default AppContext

--- a/src/components/Blobs/index.tsx
+++ b/src/components/Blobs/index.tsx
@@ -31,9 +31,7 @@ function Blobs(): JSX.Element {
       if (blobA.current) blobA.current.className = "blob about-blue"
       if (blobB.current) blobB.current.className = "blob contact-purple"
       if (blobC.current) blobC.current.className = "blob mission-yellow"
-    } else {
-			console.log("An error has occurred rendering the blob colors");
-		}
+    } 
   }, [location])
 
   return (

--- a/src/components/BlobsLayout/index.tsx
+++ b/src/components/BlobsLayout/index.tsx
@@ -2,6 +2,7 @@ import './styles.css'
 import Blobs from "../Blobs"
 import AnimatedOutlet from "../AnimatedOutlet"
 import AnimatedComponent from '../AnimatedComponent'
+import needsBlobs from '../../helpers/needsBlobs'
 
 function BlobsLayout(): JSX.Element {
   return (

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,7 +1,20 @@
-import { Link } from 'react-router-dom'
+import { useContext } from "react"
+import { Link, useNavigate } from 'react-router-dom'
 import './styles.css'
+import AppContext from "../../helpers/appContext"
 
 function Header(): JSX.Element {
+	const { user, handleLogout } = useContext(AppContext)
+	const navigate = useNavigate();
+
+	const handleClickSignInOut = () => {
+		if (user.isLoggedIn) {
+			handleLogout();
+		} else {
+			navigate("/signin")
+		}
+	}
+
   return (
 		<header id="header_container">
 			<nav id="nav_container">
@@ -10,6 +23,9 @@ function Header(): JSX.Element {
 					<Link to="/about">About Us</Link>
 					<Link to="/mission">Our Mission</Link>
 					<Link to="/contact">Contact Us</Link>
+					<a
+						onClick={handleClickSignInOut}
+					>{user.isLoggedIn ? "Sign Out" : "Sign In"}</a>
 				</div>
 			</nav>
 		</header>

--- a/src/components/HeaderLayout/index.tsx
+++ b/src/components/HeaderLayout/index.tsx
@@ -1,15 +1,17 @@
+import Header from "../Header"
 import AnimatedOutlet from "../AnimatedOutlet"
-import needsHeader from "../../helpers/needsHeader"
+import needsBlob from "../../helpers/needsBlobs"
 import AnimatedComponent from "../AnimatedComponent"
 
 // Passes the needsBlob function to the AnimatedOutlet component
 // It determines if the Blobs component need to be re-rednerd based on the current route
-function AppLayout(): JSX.Element {
+function HeaderLayout(): JSX.Element {
   return (
 		<AnimatedComponent>
-			<AnimatedOutlet pathCondition={needsHeader}/>
+      <Header />
+			<AnimatedOutlet pathCondition={needsBlob}/>
 		</AnimatedComponent>
   )
 }	
 
-export default AppLayout
+export default HeaderLayout

--- a/src/components/Hero/index.tsx
+++ b/src/components/Hero/index.tsx
@@ -1,62 +1,34 @@
-import { useEffect, useReducer } from "react"
+import { useContext } from "react"
+import appContext from "../../helpers/appContext"
 import { Link } from "react-router-dom"
 import "./styles.css"
 
-// interface state {
-// 	signedIn: boolean;
-// 	user_id?: string | null;
-// }
-
-// interface action {
-// 	type: "not_signed_in" | "signed_in";
-// 	user_id?: string | null;
-// }
-
-// function reducer(_: state, action: action): state {
-// 	switch (action.type) {
-// 		case "not_signed_in":
-// 			return {
-// 				signedIn: false,
-// 				user_id: undefined
-// 			}
-// 		case "signed_in":
-// 			return {
-// 				signedIn: true,
-// 				user_id: action.user_id
-// 			}
-// 	}
-// }
-
-interface HeroProps {
-	userID?: string | null;
-}
-
-function Hero({ userID }: HeroProps) {
-	// const [ state, dispatch ] = useReducer(reducer, {
-	// 	signedIn: false
-	// });
-
-	// useEffect(() => {
-	// 	const user_id = localStorage.getItem("user_id");
-	// 	const type = user_id ? "signed_in" : "not_signed_in"
-
-	// 	dispatch({ type, user_id })
-	// }, []);
-
+function Hero() {
+  const { user } = useContext(appContext);
+  const { userID } = user;
 
   return (
-		<div id="hero_container">
-			<div id="hero-text_container">
-				<h1>Learn and Excel.</h1>
-				<h2>Transform your education with media.</h2>
-			</div>
-			<div id="hero-buttons_container">
-				<Link to="/about" className="hero_button">Learn More</Link>	
-				<Link 
-					to={ userID ? `/${userID}/videos` : "/signin"} 
-					className="hero_button">Watch Videos</Link>
-			</div>
-		</div>
+    <div id="hero_container">
+      <div id="hero-text_container">
+        <h1>Learn and Excel.</h1>
+        <h2>Transform your education with media.</h2>
+      </div>
+      <div id="hero-buttons_container">
+        <Link to="/about" className="hero_button">Learn More</Link>	
+        {userID ? (
+          <Link 
+            to={`/${userID}/videos`} 
+            className="hero_button"
+          >Watch Videos</Link>
+        ) : (
+          <Link 
+            to="/signin" 
+            className="hero_button"
+            state={{ from: "/:user_id/videos" }}
+          >Watch Videos</Link>
+        )}
+      </div>
+    </div>
   )
 }
 

--- a/src/components/PrivateRoute/index.tsx
+++ b/src/components/PrivateRoute/index.tsx
@@ -1,17 +1,21 @@
 
-import { Navigate, useLocation  } from "react-router-dom"
+import { useEffect, useContext } from "react"
+import { useNavigate, Navigate, useLocation  } from "react-router-dom"
 import AnimatedOutlet from "../AnimatedOutlet"
+import AppContext from "../../helpers/appContext"
 
-interface PrivateRouteProps {
-	isAuthenticated: boolean;
-}
+function PrivateRoute() {
+	const navigate = useNavigate();
+	const location = useLocation();
+	const { user } = useContext(AppContext);
 
-function PrivateRoute({ isAuthenticated }: PrivateRouteProps) {
-	return (
-		isAuthenticated ? 
-			<AnimatedOutlet /> : 
-			<Navigate to="/login"/>
-	)
+	useEffect(() => {
+		if (!user.isLoggedIn) {
+			navigate("/signin", { state: { from: location.pathname } });
+		}
+	}, [user.isLoggedIn, navigate, location.pathname]);
+
+	return user.isLoggedIn ? <AnimatedOutlet /> : null;
 }
 
 export default PrivateRoute

--- a/src/components/SignIn/index.tsx
+++ b/src/components/SignIn/index.tsx
@@ -2,16 +2,12 @@ import SignInText from "../SignInText"
 import SignInForm from "../SignInForm"
 import "./styles.css"
 
-interface SignInProps {
-	handleLogin: (userID: string) => void
-}
-
-function SignIn({ handleLogin }: SignInProps) {
+function SignIn() {
   return (
     <div id="signin-page_container">
 			<div id="signin_container">
 				<SignInText />
-				<SignInForm handleLogin={handleLogin}/>
+				<SignInForm />
 			</div>
     </div>
   )

--- a/src/components/SignInForm/index.tsx
+++ b/src/components/SignInForm/index.tsx
@@ -1,74 +1,66 @@
-import { useState } from "react"
-import { useNavigate, Link } from "react-router-dom"
+import { useState, useEffect, useContext } from "react"
+import { useNavigate, useLocation, Link, Navigate } from "react-router-dom"
+import AppContext from "../../helpers/appContext"; 
 import "./styles.css"
 
-interface SignInFormProps {
-	originalPath?: string
-	handleLogin: (userID: string) => void
-}
 
-function SignInForm({ originalPath, handleLogin }: SignInFormProps) {
-	const navigate = useNavigate();
-	const [ firstName, setFirstName ] = useState("");
-	const [ lastName, setLastName ] = useState("");
+function SignInForm() {
+  const { handleLogin } = useContext(AppContext);
 
-	const validateForm = () => {
-		return !(firstName.trim() && lastName.trim());
-	}
+  const [ firstName, setFirstName ] = useState("");
+  const [ lastName, setLastName ] = useState("");
 
-	const handleSubmitForm = (e: React.FormEvent) => {
-		e.preventDefault();
 
-		const userID = [firstName, lastName].join("_");
-		handleLogin(userID);
-	}
+  const validateForm = () => {
+    return !(firstName.trim() && lastName.trim());
+  }
 
-	const handleClickLeave = () => {
-		navigate("/")
-	}
+  const handleSubmitForm = (e: React.FormEvent) => {
+    e.preventDefault();
 
-	const handleFirstNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		console.log(e.target.value)
-		setFirstName(e.target.value);
-	}
+    const userID = [firstName, lastName].join("_");
+    handleLogin(userID);
+  }
 
-	const handleLastNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		setLastName(e.target.value);
-	}
+  const handleFirstNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFirstName(e.target.value);
+  }
+
+  const handleLastNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setLastName(e.target.value);
+  }
 
   return (
-		<form id="signin_form" onSubmit={handleSubmitForm}>
-			{/* <label htmlFor="first-name_input">First Name:</label> */}
-			<input
-				className="signin_input"
-				id="first-name_input" 
-				type="text" 
-				onChange={handleFirstNameChange}
-				value={firstName}
-				placeholder={"First Name"}
-			/>
+    <form id="signin_form" onSubmit={handleSubmitForm}>
+      <input
+        className="signin_input"
+        id="first-name_input" 
+        type="text" 
+        onChange={handleFirstNameChange}
+        value={firstName}
+        placeholder={"First Name"}
+      />
 
-			{/* <label htmlFor="last-name_input">Last Name:</label> */}
-			<input 
-				className="signin_input"
-				id="last-name_input" 
-				type="text" 
-				onChange={handleLastNameChange}
-				value={lastName}
-				placeholder={"Last Name"}
-			/>
+      <input 
+        className="signin_input"
+        id="last-name_input" 
+        type="text" 
+        onChange={handleLastNameChange}
+        value={lastName}
+        placeholder={"Last Name"}
+      />
 
-			<div id="signin-buttons_container">
-				<Link to="/"className="signin_button">Cancel</Link>
+      <div id="signin-buttons_container">
+        <Link to="/" className="signin_button">Cancel</Link>
 
-				<button 
-					className="signin_button"
-					type="submit"
-					disabled={validateForm()}
-				>Sign In</button>
-			</div>
+        <button 
+          className="signin_button"
+          type="submit"
+          disabled={validateForm()}
+        >Sign In</button>
+      </div>
 
-		</form>
+    </form>
   )
 }
 

--- a/src/components/SignInForm/styles.css
+++ b/src/components/SignInForm/styles.css
@@ -49,11 +49,17 @@
 	
 	border: 0.1vw solid var(--soft-black);
 	border-radius: 2vw;
-
 	transition: background-color 0.3s, color 0.3s;
 }
 
 .signin_button:hover {
 	background-color: var(--soft-black);
 	color: var(--light-sand);
+}
+
+.signin_button:disabled,
+.signin_button:disabled:hover {
+	background: transparent;
+	border: 0.1vw solid gray;
+	color: gray;
 }

--- a/src/components/pages/SignInPage.tsx
+++ b/src/components/pages/SignInPage.tsx
@@ -1,16 +1,10 @@
-import { useState, useEffect } from 'react'
-
 import AnimatedComponent from "../AnimatedComponent"
 import SignIn from "../SignIn"
 
-interface SignInPageProps {
-	handleLogin: (userID: string) => void
-}
-
-function SignInPage({ handleLogin }: SignInPageProps) {
+function SignInPage() {
   return (
     <AnimatedComponent>
-      <SignIn handleLogin={handleLogin}/>
+      <SignIn />
     </AnimatedComponent>
   )
 }

--- a/src/components/pages/VideosPage.tsx
+++ b/src/components/pages/VideosPage.tsx
@@ -1,13 +1,19 @@
 import { useState, useEffect } from 'react'
 import AnimatedComponent from '../AnimatedComponent'
 import { Link, Navigate } from 'react-router-dom'
+import getUserID from "../../helpers/getUserID"
 
 
 function VideosPage() {
+	const userID = getUserID();
+
   return (
 		<AnimatedComponent>
 			<div id="videos-page_container">
-			<Link to='/videos/2'><h1>Video</h1></Link>
+			<div id="videos-header_container">
+				<h2>Signed in as: {userID}</h2>
+				<button >Sign out</button>
+			</div>
 			</div>
 		</AnimatedComponent>
   )

--- a/src/helpers/appContext.ts
+++ b/src/helpers/appContext.ts
@@ -1,0 +1,11 @@
+import { createContext } from "react"
+
+export default createContext<AppContext>({
+	user: {
+		isLoggedIn: false,
+    userID: undefined,
+	},
+	setUser: () => {},
+	handleLogin: () => {},
+	handleLogout: () => {}
+});

--- a/src/helpers/getUserID.ts
+++ b/src/helpers/getUserID.ts
@@ -1,0 +1,5 @@
+function getUserID() {
+	return localStorage.getItem("user_id") || undefined;
+}
+
+export default getUserID;

--- a/src/helpers/needsHeader.ts
+++ b/src/helpers/needsHeader.ts
@@ -1,0 +1,12 @@
+function needsHeader(pathname: string): string {
+	const isPageWithHeader = [
+		"/",
+		"/about",
+		"/mission",
+		"/contact",
+	].includes(pathname);
+
+	return (isPageWithHeader) ? "header" : pathname;
+}
+
+export default needsHeader;

--- a/src/helpers/userReducer.ts
+++ b/src/helpers/userReducer.ts
@@ -1,0 +1,15 @@
+function userReducer(state: UserState, action: UserAction): UserState {
+	switch (action.type) {
+		case "login": {
+			return { isLoggedIn: true, userID: action.userID ? action.userID : undefined }
+		}
+		case "logout": {
+			return { isLoggedIn: false, userID: undefined }
+		}
+		default: {
+			return { ...state }	
+		}
+	}
+}
+
+export default userReducer

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,24 @@
+interface UserAction {
+	type: "login" | "logout";
+	userID?: string;
+}
+
+interface UserState {
+	isLoggedIn: boolean;
+	userID?: string;
+}
+
+interface HeaderProps {
+}
+
+interface AppLayoutProps {
+}
+
+interface AppContext {
+	user: UserState,
+	setUser: React.Dispatch<UserAction>
+	handleLogout: () => void;
+	handleLogin: (userID: string) => void;
+}
+
+type UserReducer = (state: UserState, action: UserAction) => UserState


### PR DESCRIPTION
Implemented handlers to sign-in/sign-out as users

- Users sign-in with their first name and last name (limitation of backend API)
  - `user_id: first_last`: saved to local session in user's browser
- If user attempts to visit a private route (requires authentication), they're redirected to /signin
  - After successfully signing in, user is redirected to the route they intended to visit
- User logs out, is redirected to sign-in page
- Header now includes sign-in/sign-out button